### PR TITLE
Dynamically assign PhantomJS binary path (#7)

### DIFF
--- a/lib/svg2png.js
+++ b/lib/svg2png.js
@@ -3,7 +3,7 @@
 var path = require("path");
 var execFile = require("child_process").execFile;
 
-var phantomjsCmd = path.resolve(__dirname, "../node_modules/phantomjs/bin/phantomjs");
+var phantomjsCmd = require("phantomjs").path;
 var converterFileName = path.resolve(__dirname, "./converter.js");
 
 module.exports = function svgToPng(sourceFileName, destFileName, scale, cb) {


### PR DESCRIPTION
As mentioned in issue #7, the PhantomJS binary path should be determined dynamically.

Unfortunately, I'm not able to run the tests as there seems to be another problem with the standard PhantomJS binary on my box (I'm running a Hardened Gentoo Linux, and the PhantomJS coming with Node somehow doesn't pass the security restrictions). This is a problem specific to my setup though, and the submitted patch should work for others. Could someone else please run the tests?

Cheers,
Joschi
