### PR TITLE
Have Travis update npm before installing dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 node_js:
   - "0.8"
   - "0.10"
+before_install:
+  - npm install -g npm


### PR DESCRIPTION
This solves the first issue in #9 by updating `npm` so that the `^` semver operator is recognized and supported.
