### PR TITLE
Dropped usage of deprecated phantom.args array

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -2,7 +2,7 @@
 /*global phantom: false*/
 
 var webpage = require("webpage"),
-system = require('system');
+system = require("system");
 
 if (system.args.length !== 4) {
     console.error("Usage: converter.js source dest scale");

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -1,13 +1,14 @@
 "use strict";
 /*global phantom: false*/
 
-var webpage = require("webpage");
+var webpage = require("webpage"),
+system = require('system');
 
-if (phantom.args.length !== 3) {
+if (system.args.length !== 4) {
     console.error("Usage: converter.js source dest scale");
     phantom.exit();
 } else {
-    convert(phantom.args[0], phantom.args[1], Number(phantom.args[2]));
+    convert(system.args[1], system.args[2], Number(system.args[3]));
 }
 
 function convert(source, dest, scale) {


### PR DESCRIPTION
The `phantom.args` list [is deprecated](http://phantomjs.org/api/phantom/property/args.html) in newer versions of PhantomJS, so this one substitutes it with `system.args` (should be safe for older versions as well).