### PR TITLE
Explicitly specify PNG as the output format

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -40,7 +40,7 @@ function convert(source, dest, scale) {
 
         // This delay is I guess necessary for the resizing to happen?
         setTimeout(function () {
-            page.render(dest);
+            page.render(dest, { format: "png" });
             phantom.exit();
         }, 0);
     });


### PR DESCRIPTION
Currently, when rendering, svg2png lets PhantomJS determine the output format. According to [the documentation](http://phantomjs.org/api/webpage/method/render.html), PhantomJS uses the output file extension to choose the correct output format. However, this logic breaks down when the output file has an unusual extension or no extension at all. This pull request forces the output extension to always be PNG. The downside of this is that users will no longer be able to use this tool to generate GIFs, JPEGs, or PDFs from SVGs. My reasoning is that since this project is called svg2**png** that is an appropriate restriction, but as the owner, what are your thoughts regarding this?