### PR TITLE
Added the ability to render multiple SVGs in one go

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,20 @@ svg2png("source.svg", "dest.png", 1.2, function (err) {
 
 The scale factor is relative to the SVG's `viewbox` or `width`/`height` attributes, for the record.
 
+Do you want to render many SVGs in one go? Totally possible!
+
+```js
+// Render to two specific targets
+svg2png([ 'source1.svg', 'source2.svg' ], [ 'source1.png', 'source2.png' ], 2, function(err) {
+  // Both files got rendered and scaled 2x
+});
+
+// Render to a directory
+svg2png([ 'my.svg', 'other.svg' ], 'images/', function(err) {
+  // We now have images/my.png and images/other.png
+});
+```
+
 svg2png is built on the latest in [PhantomJS][] technology to render your SVGs using a headless WebKit instance. I have
 found this to produce much more accurate renderings than other solutions like GraphicsMagick or Inkscape. Plus, it's
 easy to install cross-platform due to the excellent [phantomjs][package] npm package—you don't even need to have

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -4,12 +4,34 @@
 
 var webpage = require("webpage");
 var system = require("system");
+var argv = {
+    scale: 1.0
+};
 
-if (system.args.length !== 4) {
-    console.error("Usage: converter.js source dest scale");
+if (!processArgs()) {
+    console.error("Usage: converter.js source dest [scale]");
     phantom.exit();
 } else {
-    convert(system.args[1], system.args[2], Number(system.args[3]));
+    convert(argv.source, argv.dest, argv.scale);
+}
+
+/**
+ * Processes the arguments passed and returns whether they are valid
+ */
+function processArgs() {
+    var args = system.args;
+    for (var i = 1; i < args.length; i++) {
+        // Ignoring flags, the args are order specific: source, dest, scale
+        if (!argv.hasOwnProperty('source')) {
+            argv.source = args[i];
+        } else if (!argv.hasOwnProperty('dest')) {
+            argv.dest = args[i];
+        } else if (!isNaN(args[i] - 0)) {
+            argv.scale = Number(args[i]);
+        }
+    }
+
+    return argv.hasOwnProperty('source') && argv.hasOwnProperty('dest');
 }
 
 function convert(source, dest, scale) {

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -5,11 +5,17 @@
 var webpage = require("webpage");
 var system = require("system");
 var Promise = require("bluebird");
+var fs = require("fs");
 
 var BAD_DIMENSIONS = 1;
 var BAD_FILE = 2;
 
 var argv = {};
+
+phantom.onError = function(err) {
+    console.error("Phantom died unexpectedly");
+    console.error(err);
+}
 
 if (!processArgs()) {
     console.error("Usage: converter.js source dest [scale]");
@@ -26,8 +32,11 @@ function processArgs() {
     var retVal = false;
     for (var i = 1; i < args.length; i++) {
 
-        if (args[i] === "--multiple-images") {
-            argv.multiImage = true;
+        if (args[i] === "--multiple-sources") {
+            argv.multiSources = true;
+        } else if (args[i] === "--multiple-dests") {
+            argv.multiDests = true;
+
         // Ignoring flags, the args are order specific: source, dest, scale
         } else if (!argv.hasOwnProperty("source")) {
             argv.source = args[i];
@@ -41,12 +50,11 @@ function processArgs() {
     argv.scale = argv.scale || 1.0;
     retVal = argv.hasOwnProperty("source") && argv.hasOwnProperty("dest");
 
-    if (retVal && argv.multiImage) {
-        argv.source = JSON.parse(argv.source);
-        try {
-            var dest = JSON.parse(argv.dest);
-            argv.dest = dest;
-        } catch (e) {}
+    if (retVal && argv.multiSources) {
+        argv.source = JSON.parse(fs.read(argv.source));
+    }
+    if (retVal && argv.multiDests) {
+        argv.dest = JSON.parse(fs.read(argv.dest));
     }
 
     return retVal;
@@ -54,8 +62,8 @@ function processArgs() {
 
 function generateDestName(source) {
     var retVal = argv.dest;
-    if (argv.multiImage) {
-        if (argv.dest instanceof Array) {
+    if (argv.multiSources) {
+        if (argv.multiDests) {
             retVal = argv.dest.shift();
 
         // In the case of an array of inputs and a single output (directory),
@@ -78,11 +86,11 @@ function conversionFailed(err) {
 }
 
 function conversionBegin() {
-    var source = argv.multiImage ? argv.source.shift() : argv.source;
+    var source = argv.multiSources ? argv.source.shift() : argv.source;
     var dest = generateDestName(source);
 
     convert(source, dest, argv.scale).then(function() {
-        if (argv.multiImage && argv.source.length > 0) {
+        if (argv.multiSources && argv.source.length > 0) {
             conversionBegin();
         } else {
             phantom.exit();

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -4,7 +4,7 @@
 
 var webpage = require("webpage");
 var system = require("system");
-var Promise = require('bluebird');
+var Promise = require("bluebird");
 
 var BAD_DIMENSIONS = 1;
 var BAD_FILE = 2;
@@ -26,20 +26,20 @@ function processArgs() {
     var retVal = false;
     for (var i = 1; i < args.length; i++) {
 
-        if (args[i] === '--multiple-images') {
+        if (args[i] === "--multiple-images") {
             argv.multiImage = true;
         // Ignoring flags, the args are order specific: source, dest, scale
-        } else if (!argv.hasOwnProperty('source')) {
+        } else if (!argv.hasOwnProperty("source")) {
             argv.source = args[i];
-        } else if (!argv.hasOwnProperty('dest')) {
+        } else if (!argv.hasOwnProperty("dest")) {
             argv.dest = args[i];
-        } else if (!argv.hasOwnProperty('scale') && !isNaN(args[i] - 0)) {
+        } else if (!argv.hasOwnProperty("scale") && !isNaN(args[i] - 0)) {
             argv.scale = Number(args[i]);
         }
     }
 
     argv.scale = argv.scale || 1.0;
-    retVal = argv.hasOwnProperty('source') && argv.hasOwnProperty('dest');
+    retVal = argv.hasOwnProperty("source") && argv.hasOwnProperty("dest");
 
     if (retVal && argv.multiImage) {
         argv.source = JSON.parse(argv.source);
@@ -61,23 +61,23 @@ function generateDestName(source) {
         // In the case of an array of inputs and a single output (directory),
         // the destination filename will be input_file.png
         } else {
-            retVal = source.split('/').pop().split('.');
+            retVal = source.split("/").pop().split(".");
             retVal.pop();
-            retVal = argv.dest + '/' + retVal.join('.') + '.png';
+            retVal = argv.dest + "/" + retVal.join(".") + ".png";
         }
     }
     return retVal;
 }
 
 function conversionFailed(err) {
-    console.error('[' + err.file + '] ' + err.message);
+    console.error("[" + err.file + "] " + err.message);
     if (err.exception) {
         console.error(err.exception);
     }
     phantom.exit();
 }
 
-function conversionBegin(thing) {
+function conversionBegin() {
     var source = argv.multiImage ? argv.source.shift() : argv.source;
     var dest = generateDestName(source);
 
@@ -96,7 +96,7 @@ function convert(source, dest, scale) {
 
         page.open(source, function (status) {
             if (status !== "success") {
-                reject({ err: BAD_FILE, message: 'Unable to load the source file.', file: source });
+                reject({ err: BAD_FILE, message: "Unable to load the source file.", file: source });
                 return;
             }
 
@@ -110,7 +110,7 @@ function convert(source, dest, scale) {
                     page.zoomFactor = scale;
                 }
             } catch (e) {
-                reject({ err: BAD_DIMENSIONS, message: 'Unable to calculate dimensions.', file: source, exception: e });
+                reject({ err: BAD_DIMENSIONS, message: "Unable to calculate dimensions.", file: source, exception: e });
                 return;
             }
 

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -4,15 +4,18 @@
 
 var webpage = require("webpage");
 var system = require("system");
-var argv = {
-    scale: 1.0
-};
+var Promise = require('bluebird');
+
+var BAD_DIMENSIONS = 1;
+var BAD_FILE = 2;
+
+var argv = {};
 
 if (!processArgs()) {
     console.error("Usage: converter.js source dest [scale]");
     phantom.exit();
 } else {
-    convert(argv.source, argv.dest, argv.scale);
+    conversionBegin();
 }
 
 /**
@@ -20,51 +23,104 @@ if (!processArgs()) {
  */
 function processArgs() {
     var args = system.args;
+    var retVal = false;
     for (var i = 1; i < args.length; i++) {
+
+        if (args[i] === '--multiple-images') {
+            argv.multiImage = true;
         // Ignoring flags, the args are order specific: source, dest, scale
-        if (!argv.hasOwnProperty('source')) {
+        } else if (!argv.hasOwnProperty('source')) {
             argv.source = args[i];
         } else if (!argv.hasOwnProperty('dest')) {
             argv.dest = args[i];
-        } else if (!isNaN(args[i] - 0)) {
+        } else if (!argv.hasOwnProperty('scale') && !isNaN(args[i] - 0)) {
             argv.scale = Number(args[i]);
         }
     }
 
-    return argv.hasOwnProperty('source') && argv.hasOwnProperty('dest');
+    argv.scale = argv.scale || 1.0;
+    retVal = argv.hasOwnProperty('source') && argv.hasOwnProperty('dest');
+
+    if (retVal && argv.multiImage) {
+        argv.source = JSON.parse(argv.source);
+        try {
+            var dest = JSON.parse(argv.dest);
+            argv.dest = dest;
+        } catch (e) {}
+    }
+
+    return retVal;
+}
+
+function generateDestName(source) {
+    var retVal = argv.dest;
+    if (argv.multiImage) {
+        if (argv.dest instanceof Array) {
+            retVal = argv.dest.shift();
+
+        // In the case of an array of inputs and a single output (directory),
+        // the destination filename will be input_file.png
+        } else {
+            retVal = source.split('/').pop().split('.');
+            retVal.pop();
+            retVal = argv.dest + '/' + retVal.join('.') + '.png';
+        }
+    }
+    return retVal;
+}
+
+function conversionFailed(err) {
+    console.error('[' + err.file + '] ' + err.message);
+    if (err.exception) {
+        console.error(err.exception);
+    }
+    phantom.exit();
+}
+
+function conversionBegin(thing) {
+    var source = argv.multiImage ? argv.source.shift() : argv.source;
+    var dest = generateDestName(source);
+
+    convert(source, dest, argv.scale).then(function() {
+        if (argv.multiImage && argv.source.length > 0) {
+            conversionBegin();
+        } else {
+            phantom.exit();
+        }
+    }).catch(conversionFailed);
 }
 
 function convert(source, dest, scale) {
-    var page = webpage.create();
+    return new Promise(function(resolve, reject) {
+        var page = webpage.create();
 
-    page.open(source, function (status) {
-        if (status !== "success") {
-            console.error("Unable to load the source file.");
-            phantom.exit();
-            return;
-        }
-
-        try {
-            var dimensions = getSvgDimensions(page);
-            page.viewportSize = {
-                width: Math.round(dimensions.width * scale),
-                height: Math.round(dimensions.height * scale)
-            };
-            if (dimensions.shouldScale) {
-                page.zoomFactor = scale;
+        page.open(source, function (status) {
+            if (status !== "success") {
+                reject({ err: BAD_FILE, message: 'Unable to load the source file.', file: source });
+                return;
             }
-        } catch (e) {
-            console.error("Unable to calculate dimensions.");
-            console.error(e);
-            phantom.exit();
-            return;
-        }
 
-        // This delay is I guess necessary for the resizing to happen?
-        setTimeout(function () {
-            page.render(dest, { format: "png" });
-            phantom.exit();
-        }, 0);
+            try {
+                var dimensions = getSvgDimensions(page);
+                page.viewportSize = {
+                    width: Math.round(dimensions.width * scale),
+                    height: Math.round(dimensions.height * scale)
+                };
+                if (dimensions.shouldScale) {
+                    page.zoomFactor = scale;
+                }
+            } catch (e) {
+                reject({ err: BAD_DIMENSIONS, message: 'Unable to calculate dimensions.', file: source, exception: e });
+                return;
+            }
+
+            // This delay is I guess necessary for the resizing to happen?
+            setTimeout(function () {
+                page.render(dest, { format: "png" });
+                page.close();
+                resolve();
+            }, 0);
+        });
     });
 }
 

--- a/lib/svg2png.js
+++ b/lib/svg2png.js
@@ -12,7 +12,23 @@ module.exports = function svgToPng(sourceFileName, destFileName, scale, cb) {
         scale = 1.0;
     }
 
-    var args = [converterFileName, sourceFileName, destFileName, scale];
+    // Check for multiple outputs
+    if (destFileName instanceof Array) {
+        // The input needs to also be an array and of the same length
+        if (!(sourceFileName instanceof Array) || sourceFileName.length !== destFileName.length) {
+            throw "Array of outputs must be used with an array of inputs of the same length.";
+        }
+        destFileName = JSON.stringify(destFileName);
+    }
+
+    // Handle multiple incoming files
+    var flag = "";
+    if (sourceFileName instanceof Array) {
+        sourceFileName = JSON.stringify(sourceFileName);
+        flag = "--multiple-images";
+    }
+
+    var args = [converterFileName, sourceFileName, destFileName, scale, flag];
     execFile(phantomjsCmd, args, function (err, stdout, stderr) {
         if (err) {
             cb(err);

--- a/lib/svg2png.js
+++ b/lib/svg2png.js
@@ -2,11 +2,18 @@
 
 var path = require("path");
 var execFile = require("child_process").execFile;
+var tmp = require("tmp");
+var fs = require("fs");
 
 var phantomjsCmd = require("phantomjs").path;
 var converterFileName = path.resolve(__dirname, "./converter.js");
 
 module.exports = function svgToPng(sourceFileName, destFileName, scale, cb) {
+    var flags = [];
+    var sourceFiles;
+    var destFiles;
+    var temp;
+
     if (typeof scale === "function") {
         cb = scale;
         scale = 1.0;
@@ -18,17 +25,21 @@ module.exports = function svgToPng(sourceFileName, destFileName, scale, cb) {
         if (!(sourceFileName instanceof Array) || sourceFileName.length !== destFileName.length) {
             throw "Array of outputs must be used with an array of inputs of the same length.";
         }
-        destFileName = JSON.stringify(destFileName);
+        destFiles = tmp.fileSync();
+        fs.writeFileSync(destFiles.name, JSON.stringify(destFileName));
+        destFileName = destFiles.name;
+        flags.push("--multiple-dests");
     }
+
 
     // Handle multiple incoming files
-    var flag = "";
     if (sourceFileName instanceof Array) {
-        sourceFileName = JSON.stringify(sourceFileName);
-        flag = "--multiple-images";
+        sourceFiles = tmp.fileSync();
+        fs.writeFileSync(sourceFiles.name, JSON.stringify(sourceFileName));
+        sourceFileName = sourceFiles.name;
+        flags.push("--multiple-sources");
     }
-
-    var args = [converterFileName, sourceFileName, destFileName, scale, flag];
+    var args = [converterFileName, sourceFileName, destFileName, scale ].concat(flags);
     execFile(phantomjsCmd, args, function (err, stdout, stderr) {
         if (err) {
             cb(err);
@@ -39,5 +50,14 @@ module.exports = function svgToPng(sourceFileName, destFileName, scale, cb) {
         } else {
             cb(null);
         }
+
+        // Close out temp files
+        if (sourceFiles) {
+            sourceFiles.removeCallback();
+        }
+        if (destFiles) {
+            destFiles.removeCallback();
+        }
+
     });
 };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "bluebird": "^3.0.5",
-    "phantomjs": "^1.9.18"
+    "phantomjs": "^1.9.18",
+    "tmp": "0.0.28"
   },
   "devDependencies": {
     "chai": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "jshint lib && jshint test"
   },
   "dependencies": {
+    "bluebird": "^3.0.5",
     "phantomjs": "^1.9.18"
   },
   "devDependencies": {

--- a/test/integration.js
+++ b/test/integration.js
@@ -15,7 +15,7 @@ var RENDER_DIFFERENCE_TOLERANCE = 1024;
 function assertCloseEnough(file1, file2) {
     var stats1 = fs.statSync(file1);
     var stats2 = fs.statSync(file2);
-    (Math.abs(stats1.size - stats2.size) < RENDER_DIFFERENCE_TOLERANCE).should.be.ok;
+    (Math.abs(stats1.size - stats2.size) < RENDER_DIFFERENCE_TOLERANCE).should.equal(true);
 }
 
 specify("Scale 1.svg to 80%", function (done) {
@@ -69,7 +69,7 @@ specify("Scales 5.svg correctly despite viewBox + fixed width/height", function 
 });
 
 specify("Render an array of inputs to a single target directory", function (done) {
-    svg2png([ relative("images/3.svg"), relative("images/4.svg") ], relative('images/'), function (err) {
+    svg2png([ relative("images/3.svg"), relative("images/4.svg") ], relative("images/"), function (err) {
         if (err) {
             return done(err);
         }
@@ -82,7 +82,9 @@ specify("Render an array of inputs to a single target directory", function (done
 });
 
 specify("Render an array of inputs to an array of targets", function (done) {
-    svg2png([ relative("images/3.svg"), relative("images/4.svg") ], [ relative('images/3-actual.png'), relative('images/4-actual.png') ], function (err) {
+    var inFiles = [ relative("images/3.svg"), relative("images/4.svg") ];
+    var outFiles = [ relative("images/3-actual.png"), relative("images/4-actual.png") ];
+    svg2png(inFiles, outFiles, function (err) {
         if (err) {
             return done(err);
         }

--- a/test/integration.js
+++ b/test/integration.js
@@ -68,6 +68,32 @@ specify("Scales 5.svg correctly despite viewBox + fixed width/height", function 
     });
 });
 
+specify("Render an array of inputs to a single target directory", function (done) {
+    svg2png([ relative("images/3.svg"), relative("images/4.svg") ], relative('images/'), function (err) {
+        if (err) {
+            return done(err);
+        }
+
+        assertCloseEnough(relative("images/3-expected.png"), relative("images/3-actual.png"));
+        assertCloseEnough(relative("images/4-expected.png"), relative("images/4-actual.png"));
+
+        done();
+    });
+});
+
+specify("Render an array of inputs to an array of targets", function (done) {
+    svg2png([ relative("images/3.svg"), relative("images/4.svg") ], [ relative('images/3-actual.png'), relative('images/4-actual.png') ], function (err) {
+        if (err) {
+            return done(err);
+        }
+
+        assertCloseEnough(relative("images/3-expected.png"), relative("images/3-actual.png"));
+        assertCloseEnough(relative("images/4-expected.png"), relative("images/4-actual.png"));
+
+        done();
+    });
+});
+
 it("should pass through errors that occur while calculating dimensions", function (done) {
     svg2png(relative("images/invalid.svg"), relative("images/invalid-actual.png"), function (err) {
         should.exist(err);
@@ -80,13 +106,15 @@ it("should pass through errors that occur while calculating dimensions", functio
 it("should pass through errors about unloadable source files", function (done) {
     svg2png("doesnotexist.asdf", "doesnotexist.asdf2", 1.0, function (err) {
         should.exist(err);
-        err.should.have.property("message").that.equals("Unable to load the source file.");
+        err.should.have.property("message").that.equals("[doesnotexist.asdf] Unable to load the source file.");
 
         done();
     });
 });
 
 after(function () {
+    fs.unlink(relative("images/3.png"));
+    fs.unlink(relative("images/4.png"));
     fs.unlink(relative("images/1-actual.png"));
     fs.unlink(relative("images/2-actual.png"));
     fs.unlink(relative("images/3-actual.png"));

--- a/test/integration.js
+++ b/test/integration.js
@@ -5,17 +5,25 @@ var fs = require("fs");
 var should = require("chai").should();
 var svg2png = require("..");
 
+// We can't reliably reproduce the baked PNGs across
+// different machines and platforms, so we'll instead
+// assert against the file sizes being within a certain
+// amount of each other. A better way of doing this would
+// be to do a difference check, but I don't want to
+// introduce additional complexity, size, or overhead
+var RENDER_DIFFERENCE_TOLERANCE = 1024;
+function assertCloseEnough(file1, file2) {
+    var stats1 = fs.statSync(file1);
+    var stats2 = fs.statSync(file2);
+    (Math.abs(stats1.size - stats2.size) < RENDER_DIFFERENCE_TOLERANCE).should.be.ok;
+}
+
 specify("Scale 1.svg to 80%", function (done) {
     svg2png(relative("images/1.svg"), relative("images/1-actual.png"), 0.8, function (err) {
         if (err) {
             return done(err);
         }
-
-        var expected = fs.readFileSync(relative("images/1-expected.png"));
-        var actual = fs.readFileSync(relative("images/1-actual.png"));
-
-        actual.should.deep.equal(expected);
-
+        assertCloseEnough(relative("images/1-expected.png"), relative("images/1-actual.png"));
         done();
     });
 });
@@ -25,12 +33,7 @@ specify("Scale 2.svg to 180%", function (done) {
         if (err) {
             return done(err);
         }
-
-        var expected = fs.readFileSync(relative("images/2-expected.png"));
-        var actual = fs.readFileSync(relative("images/2-actual.png"));
-
-        actual.should.deep.equal(expected);
-
+        assertCloseEnough(relative("images/2-expected.png"), relative("images/2-actual.png"));
         done();
     });
 });
@@ -40,12 +43,7 @@ specify("Omit scale argument for 3.svg", function (done) {
         if (err) {
             return done(err);
         }
-
-        var expected = fs.readFileSync(relative("images/3-expected.png"));
-        var actual = fs.readFileSync(relative("images/3-actual.png"));
-
-        actual.should.deep.equal(expected);
-
+        assertCloseEnough(relative("images/3-expected.png"), relative("images/3-actual.png"));
         done();
     });
 });
@@ -55,12 +53,7 @@ specify("No green border for 4.svg", function (done) {
         if (err) {
             return done(err);
         }
-
-        var expected = fs.readFileSync(relative("images/4-expected.png"));
-        var actual = fs.readFileSync(relative("images/4-actual.png"));
-
-        actual.should.deep.equal(expected);
-
+        assertCloseEnough(relative("images/4-expected.png"), relative("images/4-actual.png"));
         done();
     });
 });
@@ -70,12 +63,7 @@ specify("Scales 5.svg correctly despite viewBox + fixed width/height", function 
         if (err) {
             return done(err);
         }
-
-        var expected = fs.readFileSync(relative("images/5-expected.png"));
-        var actual = fs.readFileSync(relative("images/5-actual.png"));
-
-        actual.should.deep.equal(expected);
-
+        assertCloseEnough(relative("images/5-expected.png"), relative("images/5-actual.png"));
         done();
     });
 });


### PR DESCRIPTION
Helping mitigate the perf overhead of batch conversions by adding the ability to handle multiple files in one request. Also addressed an issue where my machine was generating different but visually identical PNGs. All tests and docs have been updated and linting passes.