### PR TITLE
Patch/hack so that PhantomJS clips png image transparent space

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -32,6 +32,7 @@ function convert(resize) {
             }
 
             var dimensions = getSVGDimensions(page);
+
             if (!dimensions) {
                 console.error("Width or height could not be determined from either the source file or the supplied " +
                               "dimensions");
@@ -43,6 +44,8 @@ function convert(resize) {
                 width: dimensions.width,
                 height: dimensions.height
             };
+
+            page.zoomFactor = 2
         } catch (e) {
             console.error("Unable to calculate or set dimensions.");
             console.error(e);


### PR DESCRIPTION
If you don't provide any width/height, PhantomJS adds in a bounding box that does not clip transparent pixels. Adding zoomFactor solves this.

Was wondering if this is reasonable change or not - if not, close this :)