### PR TITLE
Added page.clipRect for rasterizing via PhantomJS

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -34,7 +34,7 @@ function convert(resize) {
             var dimensions = getSVGDimensions(page);
             if (!dimensions) {
                 console.error("Width or height could not be determined from either the source file or the supplied " +
-                              "dimensions");
+                    "dimensions");
                 phantom.exit();
                 return;
             }
@@ -49,16 +49,17 @@ function convert(resize) {
                 width: dimensions.width,
                 height: dimensions.height
             };
+            page.open(PREFIX + sourceBase64, function (status) {
+                var result = "data:image/png;base64," + page.renderBase64("PNG");
+                system.stdout.write(result);
+                phantom.exit();
+            })
         } catch (e) {
             console.error("Unable to calculate or set dimensions.");
             console.error(e);
             phantom.exit();
             return;
         }
-
-        var result = "data:image/png;base64," + page.renderBase64("PNG");
-        system.stdout.write(result);
-        phantom.exit();
     });
 }
 

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -43,6 +43,12 @@ function convert(resize) {
                 width: dimensions.width,
                 height: dimensions.height
             };
+            page.clipRect = {
+                top: 0,
+                left: 0,
+                width: dimensions.width,
+                height: dimensions.height
+            };
         } catch (e) {
             console.error("Unable to calculate or set dimensions.");
             console.error(e);


### PR DESCRIPTION
This might be an issue specific for my platform (running on Node.js v5.10.1 on a Gentoo box), but I need to have settings for `page.clipRect` ([docs here](http://phantomjs.org/api/webpage/property/clip-rect.html)) in place as well (alongside with `page.viewportSize`) to make the rendered PNG have the correct dimensions. If `clipRect` is missing, there will always be PhantomJS' default dimensions (400 x 300 px) kicking in for the sides being less than these defaults. I.e. an SVG supposed to render as 500 x 100 px will end up being 500 x 300 px, and a 100 x 500 px one will end up with 400 x 500 px. The `page.clipRect` might not be necessary for other platforms, but I don't see any harm for them either.