### PR TITLE
Change to older-style default parameters

### DIFF
--- a/lib/svg2png.js
+++ b/lib/svg2png.js
@@ -25,7 +25,9 @@ module.exports.sync = (sourceBuffer, options) => {
     return processResult(result);
 };
 
-function getPhantomJSArgs(options = {}) {
+function getPhantomJSArgs(options) {
+    options = typeof options === 'undefined' ? {} : options;
+
     if (options.filename !== undefined && options.url !== undefined) {
         throw new Error("Cannot specify both filename and url options");
     }


### PR DESCRIPTION
ES6-style parameter defaults break on older versions of node.