### PR TITLE
revert to older syntax for robustness

### DIFF
--- a/lib/svg2png.js
+++ b/lib/svg2png.js
@@ -25,7 +25,8 @@ module.exports.sync = (sourceBuffer, options) => {
     return processResult(result);
 };
 
-function getPhantomJSArgs(options = {}) {
+function getPhantomJSArgs(options) {
+    options = options || {};
     if (options.filename !== undefined && options.url !== undefined) {
         throw new Error("Cannot specify both filename and url options");
     }


### PR DESCRIPTION
The (options = {}) argument syntax is problematic in certain cases. I'm trying to include a library (jspcb) that requires svg2png, but nodejs 7.0.0 is barfing on the options = {} syntax.
Reverting to the older syntax addresses the issue.