### PR TITLE
Add support for rendering multiple dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ svg2png(sourceBuffer, { width: 300, height: 400 })
 
 This is especially useful for images without `width` or `height`s. You can even specify just one of them and (if the image has an appropriate `viewBox`) the other will be set to scale.
 
+It is also possible to specify dimensions as an array. This will generate the images for all specified dimensions in a single run of PhantomJS, making it more efficient than calling `svg2png` multiple times.
+
+```js
+svg2png(sourceBuffer, { dimensions: [{ width: 300, height: 400 }, { width: 600, height: 800 }] })
+    .then(buffers => {
+        const buffer300 = buffer[0];
+        const buffer600 = buffer[1];
+    })
+    .catch(e => console.error(e));
+```
+
 Finally, some SVG files reference external resources using relative paths. You can set them up for correct conversion by passing the `filename` or `url` option:
 
 ```js

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -39,40 +39,42 @@ function convert(options) {
             return;
         }
 
-        try {
-            if (options.width !== undefined || options.height !== undefined) {
-                setSVGDimensions(page, options.width, options.height);
-            }
+        var results = options.dimensions.map(function(requestedDimension) {
+            try {
+                if (requestedDimension.width !== undefined || requestedDimension.height !== undefined) {
+                    setSVGDimensions(page, requestedDimension.width, requestedDimension.height);
+                }
 
-            var dimensions = getSVGDimensions(page);
-            if (!dimensions) {
-                console.error("Width or height could not be determined from either the source file or the supplied " +
-                              "dimensions");
+                var dimensions = getSVGDimensions(page);
+                if (!dimensions) {
+                    console.error("Width or height could not be determined from either the source file or the " +
+                                  "supplied dimensions");
+                    phantom.exit();
+                    return;
+                }
+
+                setSVGDimensions(page, dimensions.width, dimensions.height);
+
+                page.viewportSize = {
+                    width: dimensions.width,
+                    height: dimensions.height
+                };
+                page.clipRect = {
+                    top: 0,
+                    left: 0,
+                    width: dimensions.width,
+                    height: dimensions.height
+                };
+            } catch (e) {
+                console.error("Unable to calculate or set dimensions.");
+                console.error(e);
                 phantom.exit();
                 return;
             }
 
-            setSVGDimensions(page, dimensions.width, dimensions.height);
-
-            page.viewportSize = {
-                width: dimensions.width,
-                height: dimensions.height
-            };
-            page.clipRect = {
-                top: 0,
-                left: 0,
-                width: dimensions.width,
-                height: dimensions.height
-            };
-        } catch (e) {
-            console.error("Unable to calculate or set dimensions.");
-            console.error(e);
-            phantom.exit();
-            return;
-        }
-
-        var result = "data:image/png;base64," + page.renderBase64("PNG");
-        system.stdout.write(result);
+            return "data:image/png;base64," + page.renderBase64("PNG");
+        });
+        system.stdout.write(results.join("|"));
         phantom.exit();
     };
 

--- a/lib/svg2png.js
+++ b/lib/svg2png.js
@@ -9,20 +9,22 @@ const converterFileName = path.resolve(__dirname, "./converter.js");
 const PREFIX = "data:image/png;base64,";
 
 module.exports = (sourceBuffer, options) => {
+    const multiple = Boolean(options && options.dimensions);
     return Promise.resolve().then(() => { // catch thrown errors
         const cp = childProcess.execFile(phantomjsCmd, getPhantomJSArgs(options), { maxBuffer: Infinity });
 
         writeBufferInChunks(cp.stdin, sourceBuffer);
 
-        return cp.promise.then(processResult);
+        return cp.promise.then(r => processResult(r, multiple));
     });
 };
 
 module.exports.sync = (sourceBuffer, options) => {
+    const multiple = Boolean(options && options.dimensions);
     const result = childProcess.spawnSync(phantomjsCmd, getPhantomJSArgs(options), {
         input: sourceBuffer.toString("utf8")
     });
-    return processResult(result);
+    return processResult(result, multiple);
 };
 
 function getPhantomJSArgs(options = {}) {
@@ -36,9 +38,21 @@ function getPhantomJSArgs(options = {}) {
         delete options.filename;
     }
 
+    let dimensions = options.dimensions;
+    if (!dimensions) {
+        dimensions = [{
+            width: options.width,
+            height: options.height
+        }];
+    }
+
     return [
         converterFileName,
-        JSON.stringify(options)
+        JSON.stringify({
+            filename: options.filename,
+            url: options.url,
+            dimensions: dimensions
+        })
     ];
 }
 
@@ -54,9 +68,13 @@ function writeBufferInChunks(writableStream, buffer) {
     writableStream.end();
 }
 
-function processResult(result) {
+function processResult(result, multiple) {
     const stdout = result.stdout.toString();
     if (stdout.startsWith(PREFIX)) {
+        if (multiple) {
+            const encoded = stdout.split("|");
+            return encoded.map((r) => new Buffer(r.substring(PREFIX.length), "base64"));
+        }
         return new Buffer(stdout.substring(PREFIX.length), "base64");
     }
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -32,6 +32,45 @@ describe("CLI", () => {
     after(() => rimraf.sync(relative("cli-test-output")));
 });
 
+describe("multiple", () => {
+  describe("async", () => {
+      specify("multiple files", () => {
+          const input = fs.readFileSync(path.resolve(__dirname, "inputs", "width-height-only.svg"));
+          const expected = [
+              fs.readFileSync(relative("success-tests/1.png")),
+              fs.readFileSync(relative("success-tests/2.png"))
+          ];
+          const options = {
+              dimensions: [
+                  { "width": 200, "height": 200 },
+                  { "width": 900, "height": 900 }
+              ]
+          };
+
+          return svg2png(input, options).then(output => expect(output).to.deep.equal(expected));
+      });
+  });
+
+  describe("sync", () => {
+      specify("multiple files", () => {
+          const input = fs.readFileSync(path.resolve(__dirname, "inputs", "width-height-only.svg"));
+          const expected = [
+              fs.readFileSync(relative("success-tests/1.png")),
+              fs.readFileSync(relative("success-tests/2.png"))
+          ];
+          const options = {
+              dimensions: [
+                  { "width": 200, "height": 200 },
+                  { "width": 900, "height": 900 }
+              ]
+          };
+
+          const output = svg2png.sync(input, options);
+          expect(output).to.deep.equal(expected);
+      });
+  });
+});
+
 
 function relative(relPath) {
     return path.resolve(__dirname, relPath);


### PR DESCRIPTION
Sometimes it is desirable to to generate multiple images from one SVG using
different dimensions.

This patch supports doing so without the need to start multiple PhantomJS
instances.

- I was hopng this increases performance of tools such as [favicons][favicons], which depends on this package.
- I wrote it in such a way that the original behaviour is not affected. This means setting `width` and `height` directly, will yield a single result, whereas an array of X `dimensions` yields an array of X results.
- No existing tests were modified.
- I don't see how the new feature fits in the existing test setup. I've added new tests.

[favicons]: https://www.npmjs.com/package/favicons