### PR TITLE
Downgrade phantomjs, fixes #77

### DIFF
--- a/lib/svg2png.js
+++ b/lib/svg2png.js
@@ -3,7 +3,7 @@ const path = require("path");
 const fileURL = require("file-url");
 const childProcess = require("pn/child_process");
 
-const phantomjsCmd = require("phantomjs-prebuilt").path;
+const phantomjsCmd = require("phantomjs").path;
 const converterFileName = path.resolve(__dirname, "./converter.js");
 
 const PREFIX = "data:image/png;base64,";

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "file-url": "^2.0.0",
-    "phantomjs-prebuilt": "^2.1.14",
+    "phantomjs": "1.9.19",
     "pn": "^1.0.0",
     "yargs": "^6.5.0"
   },


### PR DESCRIPTION
I couldn't find a 2.0.0 version on NPM so this downgrades PhantomJS to 1.9.8 (packaged as phantomjs-1.9.19 on NPM). 

66 tests are failing but I assume that's because I am on Linux.

I am not 100% on merging this as there is some quality degradation and the SVGs that were previously crashing look completely wrong. 

#77 