### PR TITLE
Amended getSVGDimensions for when size only fetchable from viewbox

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -129,6 +129,11 @@ function getSVGDimensions(page) {
         if (height && viewBoxWidth) {
             return { width: height * viewBoxWidth / viewBoxHeight, height: height };
         }
+		
+		// Default to viewbox dimensions if no width or height attributes
+		if (!width && !height && viewBoxWidth && viewBoxHeight) {
+			return { width: viewBoxWidth, height: viewBoxHeight };
+		}
 
         return null;
     });


### PR DESCRIPTION
It seems that SVG files exported from Adobe Illustrator do not contain width or height attributes and rely only on viewbox dimensions. Although I thought from your docs that you include this use case, it seems not so I added a simple condition to capture it. Now works fine - I tested on a number of files exported from AI.