### PR TITLE
Add "ignorePageErrors" option

### DIFF
--- a/bin/svg2png-cli.js
+++ b/bin/svg2png-cli.js
@@ -24,6 +24,10 @@ const argv = yargs
         type: "string",
         describe: "The output file height, in pixels"
     })
+    .option("ignore-page-errors", {
+        type: "boolean",
+        describe: "Suppress any errors from JS inside the image"
+    })
     .demand(1)
     .help(false)
     .version()
@@ -32,7 +36,7 @@ const argv = yargs
 // TODO if anyone asks for it: support stdin/stdout when run that way
 
 const input = fs.readFileSync(argv._[0]);
-const output = svg2png.sync(input, { width: argv.width, height: argv.height, filename: argv._[0] });
+const output = svg2png.sync(input, { width: argv.width, height: argv.height, filename: argv._[0], ignorePageErrors: argv.ignorePageErrors });
 
 const outputFilename = argv.output || path.basename(argv._[0], ".svg") + ".png";
 fs.writeFileSync(outputFilename, output, { flag: "wx" });

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -76,6 +76,8 @@ function convert(options) {
         phantom.exit();
     };
 
+    if(options.ignorePageErrors) page.onError = function(){};
+
     // PhantomJS will always render things empty if you choose about:blank, so that's why the different default URL.
     // PhantomJS's setContent always assumes HTML, not SVG, so we have to massage the page into usable HTML first.
     page.setContent(HTML_PREFIX + source, options.url || "http://example.com/");


### PR DESCRIPTION
Recently encountered an SVG file that contained JavaScript code that throws errors.  This option allows users to suppress errors and render the file anyway